### PR TITLE
Make multiple inclusing possible

### DIFF
--- a/software/library/littleWire.c
+++ b/software/library/littleWire.c
@@ -30,6 +30,13 @@
 /*****************************************************************************/
 #include "littleWire.h"
 
+// external variables
+lwCollection lwResults[16];
+int lw_totalDevices;
+unsigned char rxBuffer[RX_BUFFER_SIZE]; /* This has to be unsigned for the data's sake */
+unsigned char ROM_NO[8];
+int lwStatus;
+
 unsigned char	crc8;
 int		LastDiscrepancy;
 int 	LastFamilyDiscrepancy;

--- a/software/library/littleWire.h
+++ b/software/library/littleWire.h
@@ -93,9 +93,9 @@
 #define MOSI_PIN PIN4
 #define RESET_PIN PIN3
 
-unsigned char rxBuffer[RX_BUFFER_SIZE]; /* This has to be unsigned for the data's sake */
-unsigned char ROM_NO[8];
-int lwStatus;
+extern unsigned char rxBuffer[RX_BUFFER_SIZE]; /* This has to be unsigned for the data's sake */
+extern unsigned char ROM_NO[8];
+extern int lwStatus;
 
 /*! \addtogroup General
 *  @brief General library functions
@@ -108,11 +108,11 @@ typedef struct lwCollection
 {
   struct usb_device* lw_device;
   int serialNumber;  
-}lwCollection;
+} lwCollection;
 
-lwCollection lwResults[16];
+extern lwCollection lwResults[16];
 
-int lw_totalDevices;
+extern int lw_totalDevices;
 
 /**
   * Tries to cache all the littleWire devices and stores them in lwResults array. \n


### PR DESCRIPTION
If you're working on a project using the littleWire.h multiple times,
you run into linking problems (duplicate symbols). Therefore all defined
variables should be defined in the .cpp file (one place) and should not
be in the header file. If they're in the header file, they are defined
in every file that includes the header.
