### PR TITLE
Support for reading temperature/humidity from DHT11 and DHT22, bump v1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ software/adc
 software/blink
 software/blink_ws2812
 software/button
+software/dht11
 software/debugConsole
 software/fade_ws2812
 software/hardwarePWM
@@ -19,3 +20,6 @@ software/rgb_cycle_ws2812
 software/servo
 software/softPWM
 software/spi_LTC1448
+
+firmware/main.hex
+firmware/main.elf

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 For more details: <http://littlewire.cc>
 
-Current version is: **v1.3**
+Current version is: **v1.4**
 
 Previous version releases can be found at: <https://github.com/littlewire/Little-Wire/releases>
 

--- a/software/Makefile
+++ b/software/Makefile
@@ -28,6 +28,7 @@ CFLAGS  = $(USBFLAGS) $(LIBS) -I$(INCLUDE) -O -g $(OSFLAG)
 LWLIBS = littleWire littleWire_util littleWire_servo opendevice
 EXAMPLES  = adc blink blink_ws2812 rgb_cycle_ws2812 fade_ws2812 button servo i2c_blinkM
 EXAMPLES += spi_LTC1448 onewire softPWM hardwarePWM debugConsole lwbuttond i2c_nunchuck
+EXAMPLES += dht11
 
 .PHONY:	clean library docs
 

--- a/software/examples/dht11.c
+++ b/software/examples/dht11.c
@@ -1,0 +1,56 @@
+/*
+	Updated for the new firmware: July 2012
+	by ihsan Kehribar <ihsan@kehribar.me>
+	
+	Created: December 2011
+	by ihsan Kehribar <ihsan@kehribar.me>
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "littleWire.h"
+#include "littleWire_util.h"
+
+unsigned char version;
+
+dht_reading val;
+
+int main(int argc, char **argv)
+{
+	littleWire *lw = NULL;
+
+	lw = littleWire_connect();
+
+	if(lw == NULL){
+		printf("> Little Wire could not be found!\n");
+		exit(EXIT_FAILURE);
+	}
+
+	version = readFirmwareVersion(lw);
+	printf("> Little Wire firmware version: %d.%d\n",((version & 0xF0)>>4),(version&0x0F));	
+	if(version<0x14)
+	{
+		printf("> This example requires the new 1.4 version firmware. Please update soon.\n");
+		return 0;
+	}
+		
+	while(1)
+	{
+    val = dht_read(lw, DHT11);
+    if (!val.error) {
+    printf("humidity: %f, temp %f\n", (float)val.humid/10.0, (float)val.temp/10.0);
+    } else {
+      printf("Error Reading sensor!");
+    }
+		
+		if(lwStatus<0)
+		{
+			printf("> lwStatus: %d\n",lwStatus);
+			printf("> Connection error!\n");
+			return 0;
+		}
+		
+		delay(5000);
+	}
+}

--- a/software/library/littleWire.c
+++ b/software/library/littleWire.c
@@ -389,7 +389,19 @@ void ws2812_preload(littleWire* lwHandle, unsigned char r,unsigned char g,unsign
 {
 	lwStatus=usb_control_msg(lwHandle, 0xC0, 54, (g<<8) | 0x20, (b<<8) | r, rxBuffer, 8, USB_TIMEOUT);
 }
+
+dht_reading dht_read(littleWire* lwHandle, unsigned char type)
+{
+  lwStatus=usb_control_msg(lwHandle, 0xC0, 56, type, 0, rxBuffer, 8, USB_TIMEOUT);
 	
+	delay(100);
+
+  lwStatus=usb_control_msg(lwHandle, 0xC0, 40, 0, 0, rxBuffer, 8, USB_TIMEOUT);
+
+  return *(dht_reading*) (void*) rxBuffer;
+}
+
+
 int customMessage(littleWire* lwHandle,unsigned char* receiveBuffer,unsigned char command,unsigned char d1,unsigned char d2, unsigned char d3, unsigned char d4)
 {
 	int i;

--- a/software/library/littleWire.h
+++ b/software/library/littleWire.h
@@ -36,6 +36,7 @@
 #include "opendevice.h"			// common code moved to separate module
 #include "littleWire_util.h"
 #include <stdio.h>
+#include <stdint.h>
 
 #define	VENDOR_ID 0x1781
 #define	PRODUCT_ID 0x0c9f
@@ -92,6 +93,15 @@
 #define MISO_PIN PIN1
 #define MOSI_PIN PIN4
 #define RESET_PIN PIN3
+
+#define DHT11 0
+#define DHT22 1
+
+typedef struct dht_reading {
+  uint16_t humid;
+  uint16_t temp;
+  uint8_t error;
+} dht_reading;
 
 extern unsigned char rxBuffer[RX_BUFFER_SIZE]; /* This has to be unsigned for the data's sake */
 extern unsigned char ROM_NO[8];
@@ -557,6 +567,7 @@ void ws2812_preload(littleWire* lwHandle, unsigned char r,unsigned char g,unsign
 
   /*! @} */
   
+dht_reading dht_read(littleWire* lwHandle, unsigned char type);
 
 /**
 * @mainpage Introduction


### PR DESCRIPTION
I've added support for reading from the DHT11 and DHT22 temperature / humidity sensors, they use their own variant on the onewire protocol. I did a bump of the version number, I'm not sure what your policy on new feature versioning is, so if you're interested in integrating this please let me know what I need to change.

Also, I've written a [lua wrapper for the C library](https://github.com/evq/LuaLittleWire) if anyone is interested :)
